### PR TITLE
fix 'K' key binding

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -2525,10 +2525,11 @@ Terminal.prototype.keyDown = function(ev) {
       break;
     // CTRL-K
     case 75:
-      if ((!isMac && ev.ctrlKey) || (isMac && ev.metaKey)) {
+      if ((!this.isMac && ev.ctrlKey) || (this.isMac && ev.metaKey)) {
         this.clear();
         return cancel(ev);
       }
+      break;
     // F1
     case 112:
       key = '\x1bOP';


### PR DESCRIPTION
As per f/atom-term2#178, pressing 'K' just throws an error. 

This PR fixes the bug!
