### PR TITLE
Fix undefined error for 'isMac'

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -2525,7 +2525,7 @@ Terminal.prototype.keyDown = function(ev) {
       break;
     // CTRL-K
     case 75:
-      if ((!isMac && ev.ctrlKey) || (isMac && ev.metaKey)) {
+      if ((!this.isMac && ev.ctrlKey) || (this.isMac && ev.metaKey)) {
         this.clear();
         return cancel(ev);
       }

--- a/src/term.js
+++ b/src/term.js
@@ -2529,6 +2529,7 @@ Terminal.prototype.keyDown = function(ev) {
         this.clear();
         return cancel(ev);
       }
+      break;
     // F1
     case 112:
       key = '\x1bOP';


### PR DESCRIPTION
This happens to me while typing and its very annoying. I find it strange that nobody else spotted it.
